### PR TITLE
Remove log

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ Elixir.extend('stylelint', function (src, options) {
   }, options);
 
   new Elixir.Task('stylelint', function () {
-
     return gulp.src(paths.src.path)
       .pipe(stylelint(stylelintOptions))
       .pipe(gutil.noop());

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ Elixir.extend('stylelint', function (src, options) {
   }, options);
 
   new Elixir.Task('stylelint', function () {
-    this.log(paths.src);
 
     return gulp.src(paths.src.path)
       .pipe(stylelint(stylelintOptions))


### PR DESCRIPTION
Noticed that `[object Object]` got logged when starting laravel elixir with gulp.  Removed that log row.

![screenshot](https://cloud.githubusercontent.com/assets/307676/22552872/f5020428-e95a-11e6-84c3-76a95b4c3214.png)
